### PR TITLE
Problem: query model is poorly defined

### DIFF
--- a/viewdb_core/Cargo.toml
+++ b/viewdb_core/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "viewdb_core"
+version = "0.1.0"
+authors = ["Yurii Rashkovskii <yrashk@gmail.com>"]
+
+[dependencies]
+uuid = {version = "0.5", features = ["v4"], optional = true}
+
+[features]
+uuid_v4_identifier = ["uuid"]

--- a/viewdb_core/src/lib.rs
+++ b/viewdb_core/src/lib.rs
@@ -1,0 +1,95 @@
+// Copyright (c) 2017, All Contributors (see CONTRIBUTORS file)
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use std::hash::Hash;
+pub trait Identifier : Eq + Hash + Clone + Copy {
+    fn generate() -> Self;
+    fn identifier(&self) -> &[u8];
+}
+
+#[derive(PartialEq, Eq, Hash, Clone, Copy)]
+pub struct Fact<I : Identifier>(I);
+
+impl<I : Identifier> Fact<I> {
+    pub fn new() -> Self {
+        Fact::new_with_identifier(Identifier::generate())
+    }
+
+    pub fn new_with_identifier(identifier: I) -> Self {
+        Fact(identifier)
+    }
+
+    pub fn identifier(&self) -> &[u8] {
+        self.0.identifier()
+    }
+}
+
+#[cfg(feature="uuid_v4_identifier")]
+extern crate uuid;
+
+#[cfg(feature="uuid_v4_identifier")]
+#[derive(PartialEq, Eq, Hash, Clone, Copy)]
+pub struct UuidIdentifier(uuid::Uuid);
+
+#[cfg(feature="uuid_v4_identifier")]
+impl Identifier for UuidIdentifier {
+
+    fn generate() -> Self {
+        UuidIdentifier(uuid::Uuid::new_v4())
+    }
+
+    fn identifier(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
+
+pub struct Attribute<T : AsRef<[u8]>>(T, T);
+impl<T : AsRef<[u8]>> Attribute<T> {
+    pub fn new(name: T, value: T) -> Self {
+        Attribute(name, value)
+    }
+}
+
+#[derive(Clone)]
+pub struct TraitPattern<T : AsRef<[u8]> + Clone>(pub T, pub Option<T>);
+#[derive(Clone)]
+pub struct Trait<T : AsRef<[u8]> + Clone>(Vec<TraitPattern<T>>);
+
+impl<T : AsRef<[u8]> + Clone> From<Vec<TraitPattern<T>>> for Trait<T> {
+    fn from(v: Vec<TraitPattern<T>>) -> Self {
+        Trait(v)
+    }
+}
+
+impl<T : AsRef<[u8]> + Clone> Trait<T> {
+
+    pub fn iter(&self) -> ::std::slice::Iter<TraitPattern<T>> {
+        self.0.iter()
+    }
+}
+
+impl<T : AsRef<[u8]> + Clone> From<(T, Option<T>)> for TraitPattern<T> {
+    fn from((t, o): (T, Option<T>)) -> Self {
+        TraitPattern(t, o)
+    }
+}
+
+pub trait TraitResolver<T : AsRef<[u8]> + Clone> {
+    fn resolve(&self, name: T) -> &Trait<T>;
+}
+
+
+#[cfg(test)]
+mod tests {
+
+    #[cfg(feature="uuid_v4_identifier")]
+    #[test]
+    fn it_works() {
+        let fact1 = super::Fact::<super::UuidIdentifier>::new();
+        let fact2 = super::Fact::<super::UuidIdentifier>::new();
+        assert!(fact1.identifier() != fact2.identifier());
+    }
+}

--- a/viewdb_query/Cargo.toml
+++ b/viewdb_query/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "viewdb_query"
+version = "0.1.0"
+authors = ["Yurii Rashkovskii <yrashk@gmail.com>"]
+
+[dependencies]
+try_opt = "0.1.1"
+viewdb_core = { version = "0.1", path = "../viewdb_core" }

--- a/viewdb_query/README.md
+++ b/viewdb_query/README.md
@@ -1,0 +1,3 @@
+# ViewDB Query
+
+This crates provides building blocks for querying ViewDB facts. 

--- a/viewdb_query/src/condition/mod.rs
+++ b/viewdb_query/src/condition/mod.rs
@@ -1,0 +1,72 @@
+// Copyright (c) 2017, All Contributors (see CONTRIBUTORS file)
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
+pub enum Value<T : AsRef<[u8]> + Clone> {
+    Data(T),
+    Binding(T),
+    Attribute(T),
+    AttributeTxid(T),
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Condition<T : AsRef<[u8]> + Clone> {
+    // Fact scoping
+    Fact(Box<Condition<T>>),
+    // Boolean logic
+    Not(Box<Condition<T>>),
+    And(Box<Condition<T>>, Box<Condition<T>>),
+    Or(Box<Condition<T>>, Box<Condition<T>>),
+    // Trait scoping
+    Trait(T, Box<Condition<T>>),
+    // Conditions
+    Present(Value<T>),
+    Equal(Value<T>, Value<T>),
+    LessThan(Value<T>, Value<T>),
+    GreaterThan(Value<T>, Value<T>),
+    True, False,
+}
+
+pub mod processing;
+
+impl<T : AsRef<[u8]> + Clone> Condition<T> {
+
+    #[inline]
+    pub fn not(cond: Condition<T>) -> Self {
+        Condition::Not(Box::new(cond))
+    }
+
+    #[inline]
+    pub fn and(self, c2: Condition<T>) -> Self {
+        Condition::And(Box::new(self), Box::new(c2))
+    }
+
+    #[inline]
+    pub fn or(self, c2: Condition<T>) -> Self {
+        Condition::Or(Box::new(self), Box::new(c2))
+    }
+
+    #[inline]
+    pub fn trait_scope(t: T, c: Condition<T>) -> Self {
+        Condition::Trait(t, Box::new(c))
+    }
+
+    #[inline]
+    pub fn fact(c: Condition<T>) -> Self {
+        Condition::Fact(Box::new(c))
+    }
+
+}
+
+use std::ops::Not;
+
+impl<T: AsRef<[u8]> + Clone> Not for Condition<T> {
+    type Output = Condition<T>;
+
+    fn not(self) -> Self::Output {
+        Condition::Not(Box::new(self))
+    }
+}

--- a/viewdb_query/src/condition/processing.rs
+++ b/viewdb_query/src/condition/processing.rs
@@ -1,0 +1,148 @@
+// Copyright (c) 2017, All Contributors (see CONTRIBUTORS file)
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use super::{Condition, Value};
+use super::super::{TraitPattern, TraitResolver};
+
+use std::marker::PhantomData;
+
+pub trait Processor<T> where T: AsRef<[u8]> + Clone {
+    fn process(&self, condition: Condition<T>) -> Option<Condition<T>>;
+}
+
+pub trait Recursive<T> : Processor<T> where T: AsRef<[u8]> + Clone {
+    fn process_recursively(&self, condition: Condition<T>) -> Option<Condition<T>> {
+        match condition {
+            Condition::Fact(c) => Some(Condition::fact(try_opt!(self.process_recursively(try_opt!(self.process(*c)))))),
+            Condition::Trait(t, c) => Some(Condition::trait_scope(t, try_opt!(self.process_recursively(try_opt!(self.process(*c)))))),
+            Condition::And(c1, c2) => {
+                match self.process(*c1).and_then(|v| self.process_recursively(v)) {
+                    None => self.process(*c2).and_then(|v| self.process_recursively(v)),
+                    Some(c) => Some(match self.process(*c2).and_then(|v| self.process_recursively(v)) {
+                        None => c,
+                        Some(c_) => c.and(c_)
+                    })
+                }
+            },
+            Condition::Or(c1, c2) => {
+                match self.process(*c1).and_then(|v| self.process_recursively(v)) {
+                    None => self.process(*c2).and_then(|v| self.process_recursively(v)),
+                    Some(c) => Some(match self.process(*c2).and_then(|v| self.process_recursively(v)) {
+                        None => c,
+                        Some(c_) => c.or(c_)
+                    })
+                }
+            },
+            Condition::Not(c) => Some(!try_opt!(self.process_recursively(try_opt!(self.process(*c))))),
+            _ => Some(condition),
+        }
+    }
+}
+
+pub struct TraitsExpansion<T : AsRef<[u8]> + Clone + PartialOrd, R : TraitResolver<T>>(R, PhantomData<T>);
+impl<T: AsRef<[u8]> + Clone + PartialOrd, R : TraitResolver<T>> Recursive<T> for TraitsExpansion<T, R> {}
+
+
+impl<T: AsRef<[u8]> + Clone + PartialOrd, R : TraitResolver<T>> TraitsExpansion<T, R> {
+    pub fn new(resolver: R) -> Self {
+        TraitsExpansion(resolver, PhantomData)
+    }
+}
+
+impl<T: AsRef<[u8]> + Clone + PartialOrd, R : TraitResolver<T>> Processor<T> for TraitsExpansion<T, R> {
+    fn process(&self, condition: Condition<T>) -> Option<Condition<T>> {
+        match condition {
+            Condition::Trait(name, boxed) => {
+                let trait_def = self.0.resolve(name);
+                let mut cond = try_opt!(self.process(*boxed));
+                for pattern in trait_def.iter() {
+                    match pattern {
+                        &TraitPattern(ref attr, None) => {
+                            cond = cond.and(Condition::Present(Value::Attribute(attr.clone())));
+                        }
+                        &TraitPattern(ref attr, Some(ref val)) => {
+                            cond = cond.and(Condition::Equal(Value::Attribute(attr.clone()), Value::Data(val.clone())));
+                        }
+                    }
+                }
+                Some(cond)
+            },
+            c => self.process_recursively(c),
+        }
+    }
+}
+
+pub struct PresentEqualCompaction;
+impl<T: AsRef<[u8]> + Clone + PartialOrd> Recursive<T> for PresentEqualCompaction {}
+
+impl<T: AsRef<[u8]> + Clone + PartialOrd> Processor<T> for PresentEqualCompaction {
+    fn process(&self, condition: Condition<T>) -> Option<Condition<T>> {
+        fn contains_equal<T: AsRef<[u8]> + Clone + PartialOrd>(cond: &Condition<T>, attr: &Value<T>) -> bool {
+            match cond {
+                &Condition::Equal(ref a, _) if a == attr => true,
+                &Condition::Fact(ref c) => contains_equal(c, attr),
+                &Condition::And(ref c1, ref c2) => contains_equal(c1, attr) || contains_equal(c2, attr),
+                &Condition::Or(ref c1, ref c2) => contains_equal(c1, attr) && contains_equal(c2, attr),
+                _ => false,
+            }
+        }
+        match condition {
+            Condition::And(c1, c2) => {
+                match (*c1, *c2) {
+                    (Condition::Present(a1), cond) | (cond, Condition::Present(a1)) =>
+                        if contains_equal(&cond, &a1) {
+                            Some(cond)
+                        } else {
+                            Some(Condition::Present(a1).and(try_opt!(self.process(cond))))
+                        },
+                    (c1, c2) =>
+                        Some(try_opt!(self.process(c1)).and(try_opt!(self.process(c2)))),
+                }
+            },
+            c => self.process_recursively(c),
+        }
+    }
+}
+
+pub struct ComparisonSuppression;
+impl<T: AsRef<[u8]> + Clone + PartialOrd> Recursive<T> for ComparisonSuppression {}
+
+impl<T: AsRef<[u8]> + Clone + PartialOrd> Processor<T> for ComparisonSuppression {
+    fn process(&self, condition: Condition<T>) -> Option<Condition<T>> {
+        match condition {
+            Condition::Equal(Value::Data(ref v1), Value::Data(ref v2)) if v1 == v2 => None,
+            Condition::Equal(Value::Data(_), Value::Data(_)) => Some(Condition::False),
+            Condition::GreaterThan(Value::Data(ref v1), Value::Data(ref v2)) if v1 > v2 => None,
+            Condition::GreaterThan(Value::Data(_), Value::Data(_)) => Some(Condition::False),
+            Condition::LessThan(Value::Data(ref v1), Value::Data(ref v2)) if v1 < v2 => None,
+            Condition::LessThan(Value::Data(_), Value::Data(_)) => Some(Condition::False),
+            Condition::Equal(Value::Attribute(ref a1), Value::Attribute(ref a2)) if a1 == a2 => None,
+            Condition::Equal(Value::Binding(ref b1), Value::Attribute(ref b2)) if b1 == b2 => None,
+            c => self.process_recursively(c),
+        }
+    }
+}
+
+pub struct BooleanLiteralSuppression;
+impl<T: AsRef<[u8]> + Clone + PartialOrd> Recursive<T> for BooleanLiteralSuppression {}
+
+impl<T: AsRef<[u8]> + Clone + PartialOrd> Processor<T> for BooleanLiteralSuppression {
+    fn process(&self, condition: Condition<T>) -> Option<Condition<T>> {
+        match condition {
+            Condition::And(a, b) =>
+                if *a == Condition::False || *b == Condition::False {
+                    None
+                } else if *a == Condition::True {
+                    Some(*b)
+                } else if *b == Condition::True {
+                    Some(*a)
+                } else {
+                    Some(a.and(*b))
+                },
+            c => self.process_recursively(c),
+        }
+    }
+}

--- a/viewdb_query/src/lib.rs
+++ b/viewdb_query/src/lib.rs
@@ -1,0 +1,61 @@
+// Copyright (c) 2017, All Contributors (see CONTRIBUTORS file)
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#[macro_use]
+extern crate try_opt;
+extern crate viewdb_core;
+
+pub(crate) use viewdb_core::{TraitPattern, TraitResolver};
+#[cfg(test)]
+pub(crate) use viewdb_core::{Trait};
+
+mod condition;
+pub use condition::{Condition, Value};
+
+#[cfg(test)]
+mod tests {
+    use super::{Value, Trait, TraitResolver, Condition};
+    use super::Condition::{Equal};
+    use condition::processing::{Processor, TraitsExpansion, PresentEqualCompaction,
+                                ComparisonSuppression, BooleanLiteralSuppression};
+
+    #[derive(Clone)]
+    pub struct Test<T : AsRef<[u8]> + Clone>((T, Trait<T>), (T, Trait<T>), (T, Trait<T>));
+
+    impl<T : AsRef<[u8]> + Clone> TraitResolver<T> for Test<T>  {
+        fn resolve(&self, name: T) -> &Trait<T> {
+            if name.as_ref() == (self.0).0.as_ref() {
+                return &(self.0).1
+            }
+            if name.as_ref() == (self.1).0.as_ref() {
+                return &(self.1).1
+            }
+            if name.as_ref() == (self.2).0.as_ref() {
+                return &(self.2).1
+            }
+            unreachable!()
+        }
+    }
+
+    #[test]
+    fn it_works() {
+        let cond =
+            Condition::fact(
+                Condition::trait_scope("Object", Equal(Value::Attribute("https://viewdb.org/attributes#object"), Value::Data("123")))
+                .and(Condition::trait_scope("NameChanged", Equal(Value::Attribute("https://viewdb.org/attributes#value"), Value::Binding("Name"))))
+                .and(Condition::trait_scope("Timestamp", Equal(Value::Attribute("https://viewdb.org/attributes#timestamp"), Value::Binding("Timestamp"))))
+            );
+
+        let object = vec![("https://viewdb.org/attributes#object", None).into()].into();
+        let name_changed = vec![("https://viewdb.org/attributes#factType", Some("NameChanged")).into(),
+                                      ("https://viewdb.org/attributes#value", None).into()].into();
+        let timestamp = vec![("https://viewdb.org/attributes#timestamp", None).into()].into();
+
+        let te = TraitsExpansion::new(Test(("Object", object), ("NameChanged", name_changed), ("Timestamp", timestamp)));
+
+        let cond1 = BooleanLiteralSuppression.process(ComparisonSuppression.process(PresentEqualCompaction.process(te.process(cond).unwrap()).unwrap()).unwrap()).unwrap();
+        println!("{:#?}", cond1);
+    }
+}


### PR DESCRIPTION
Well, technically speaking, it's not defined at all, but
rather a vague understanding of what it should be.

Solution: lay out the first draft of the query model

This adds viewdb_core and viewdb_query crates. The reason
for the split is to enable separate use of these in systems
that might (potentially) not be backed by PumpkinDB (which
is integrated into viewdb_engine)