### PR TITLE
Problem: query condition might have no fact grouping

### DIFF
--- a/viewdb_query/Cargo.toml
+++ b/viewdb_query/Cargo.toml
@@ -6,3 +6,6 @@ authors = ["Yurii Rashkovskii <yrashk@gmail.com>"]
 [dependencies]
 try_opt = "0.1.1"
 viewdb_core = { version = "0.1", path = "../viewdb_core" }
+
+[dev-dependencies]
+assert_matches = "1.1"


### PR DESCRIPTION
Solution: add an ImplicitFact processor

This processor will wrap the condition in a Fact() unless
there are facts inside.

Also, adds a much better processor chaining method (after_that)